### PR TITLE
Remove comma in convert/source curl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ curl -X 'POST' \
     "return_as_file": false,
     "do_table_structure": true,
     "include_images": true,
-    "images_scale": 2,
+    "images_scale": 2
   },
   "http_sources": [{"url": "https://arxiv.org/pdf/2206.01062"}]
 }'


### PR DESCRIPTION
Remove comma in convert/source curl example to make it work.

Otherwise it fails with error message:
{"detail":[{"type":"json_invalid","loc":["body",607],"msg":"JSON decode error","input":{},"ctx":{"error":"Expecting property name enclosed in double quotes"}}]}%

